### PR TITLE
Add Deno configuration for Supabase functions

### DIFF
--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}


### PR DESCRIPTION
## Summary
- add a deno.json configuration under supabase/functions to enable automatic node module management
- ensure Deno can resolve npm dependencies like openai without manual installs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87ea7626c8320a43769f82d2bd433