### PR TITLE
feat: enable support chat attachments

### DIFF
--- a/src/components/support/ChatInterface.tsx
+++ b/src/components/support/ChatInterface.tsx
@@ -5,17 +5,33 @@ import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Send, MessageCircle, User, Clock } from 'lucide-react';
-import { SupportClient, SupportMessage } from '@/hooks/useSupportChat';
+import {
+  Send,
+  MessageCircle,
+  User,
+  Clock,
+  Paperclip,
+  Mic,
+  Loader2,
+  FileText,
+  Download
+} from 'lucide-react';
+import {
+  SupportClient,
+  SupportMessage,
+  SupportMessageContent
+} from '@/hooks/useSupportChat';
 import { useAuth } from '@/state/auth';
 import { formatDistanceToNow } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
 
 interface ChatInterfaceProps {
   client: SupportClient | null;
   messages: SupportMessage[];
   loading: boolean;
-  onSendMessage: (content: string) => Promise<void>;
+  onSendMessage: (content: SupportMessageContent) => Promise<void>;
 }
 
 export const ChatInterface: React.FC<ChatInterfaceProps> = ({
@@ -25,9 +41,17 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
   onSendMessage
 }) => {
   const { user } = useAuth();
+  const { toast } = useToast();
   const [newMessage, setNewMessage] = useState('');
   const [sending, setSending] = useState(false);
+  const [attachmentUploading, setAttachmentUploading] = useState<null | 'file' | 'audio'>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingDuration, setRecordingDuration] = useState(0);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const recordingIntervalRef = useRef<number | null>(null);
+  const recordingChunksRef = useRef<Blob[]>([]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -42,7 +66,10 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
 
     setSending(true);
     try {
-      await onSendMessage(newMessage);
+      await onSendMessage({
+        type: 'text',
+        text: newMessage
+      });
       setNewMessage('');
     } catch (error) {
       console.error('Erro ao enviar mensagem:', error);
@@ -65,6 +92,230 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
       .join('')
       .toUpperCase()
       .slice(0, 2);
+  };
+
+  const formatFileSize = (size: number) => {
+    if (size < 1024) return `${size} B`;
+    if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const formatDuration = (duration?: number) => {
+    if (!duration) return null;
+    const minutes = Math.floor(duration / 60);
+    const seconds = duration % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  };
+
+  const handleAttachmentUpload = async (
+    file: File,
+    type: 'file' | 'audio',
+    options?: { duration?: number }
+  ) => {
+    if (!client) return;
+
+    setAttachmentUploading(type);
+
+    try {
+      const fileExt = file.name.split('.').pop();
+      const fileName = `${Date.now()}-${Math.random().toString(36).substring(2)}.${fileExt}`;
+      const filePath = `${client.id}/${fileName}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from('support-files')
+        .upload(filePath, file, {
+          upsert: false
+        });
+
+      if (uploadError) throw uploadError;
+
+      const { data: publicUrlData, error: publicUrlError } = supabase.storage
+        .from('support-files')
+        .getPublicUrl(filePath);
+
+      if (publicUrlError) throw publicUrlError;
+
+      const payload: SupportMessageContent =
+        type === 'file'
+          ? {
+              type: 'file',
+              url: publicUrlData.publicUrl,
+              name: file.name,
+              size: file.size,
+              mimeType: file.type
+            }
+          : {
+              type: 'audio',
+              url: publicUrlData.publicUrl,
+              mimeType: file.type,
+              duration: options?.duration
+            };
+
+      await onSendMessage(payload);
+      toast({
+        title: type === 'file' ? 'Arquivo enviado' : 'Áudio enviado',
+        description:
+          type === 'file'
+            ? 'O arquivo foi enviado com sucesso.'
+            : 'A mensagem de áudio foi enviada com sucesso.'
+      });
+    } catch (error: any) {
+      console.error('Erro ao enviar anexo:', error);
+      toast({
+        title: 'Erro ao enviar',
+        description: error.message || 'Não foi possível enviar o anexo.',
+        variant: 'destructive'
+      });
+    } finally {
+      setAttachmentUploading(null);
+    }
+  };
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (!files?.length) return;
+
+    for (const file of Array.from(files)) {
+      await handleAttachmentUpload(file, 'file');
+    }
+
+    event.target.value = '';
+  };
+
+  const stopRecordingTimer = () => {
+    if (recordingIntervalRef.current) {
+      window.clearInterval(recordingIntervalRef.current);
+      recordingIntervalRef.current = null;
+    }
+  };
+
+  const stopRecording = () => {
+    stopRecordingTimer();
+    mediaRecorderRef.current?.stop();
+    mediaRecorderRef.current = null;
+    setIsRecording(false);
+  };
+
+  const startRecording = async () => {
+    if (!client) return;
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      toast({
+        title: 'Gravação não suportada',
+        description: 'Seu navegador não suporta captura de áudio.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream);
+      recordingChunksRef.current = [];
+
+      recorder.addEventListener('dataavailable', (event) => {
+        if (event.data.size > 0) {
+          recordingChunksRef.current.push(event.data);
+        }
+      });
+
+      recorder.addEventListener('stop', async () => {
+        stream.getTracks().forEach(track => track.stop());
+        const blob = new Blob(recordingChunksRef.current, {
+          type: recorder.mimeType || 'audio/webm'
+        });
+
+        if (blob.size === 0) {
+          toast({
+            title: 'Gravação vazia',
+            description: 'Nenhum áudio foi capturado. Tente novamente.',
+            variant: 'destructive'
+          });
+          return;
+        }
+
+        const file = new File([blob], `gravacao-${Date.now()}.webm`, {
+          type: blob.type
+        });
+
+        await handleAttachmentUpload(file, 'audio', {
+          duration: recordingDuration
+        });
+
+        setRecordingDuration(0);
+      });
+
+      recorder.start();
+      mediaRecorderRef.current = recorder;
+      setIsRecording(true);
+      setRecordingDuration(0);
+      recordingIntervalRef.current = window.setInterval(() => {
+        setRecordingDuration((prev) => prev + 1);
+      }, 1000);
+    } catch (error: any) {
+      console.error('Erro ao iniciar gravação de áudio:', error);
+      toast({
+        title: 'Erro na gravação',
+        description:
+          error.message || 'Não foi possível iniciar a gravação de áudio. Verifique as permissões.',
+        variant: 'destructive'
+      });
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (isRecording) {
+        stopRecording();
+      }
+      stopRecordingTimer();
+    };
+  }, [isRecording]);
+
+  const renderMessageContent = (message: SupportMessage) => {
+    switch (message.content.type) {
+      case 'file':
+        return (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              <div>
+                <p className="text-sm font-medium break-words">{message.content.name}</p>
+                <p className="text-xs text-muted-foreground">{formatFileSize(message.content.size)}</p>
+              </div>
+            </div>
+            <a
+              href={message.content.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+            >
+              <Download className="h-3 w-3" /> Baixar arquivo
+            </a>
+          </div>
+        );
+      case 'audio':
+        return (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm">
+              <Mic className="h-4 w-4" />
+              <span>Mensagem de áudio</span>
+              {formatDuration(message.content.duration) && (
+                <span className="text-xs text-muted-foreground">
+                  {formatDuration(message.content.duration)}
+                </span>
+              )}
+            </div>
+            <audio controls src={message.content.url} className="w-full" preload="auto" />
+          </div>
+        );
+      default:
+        return (
+          <p className="text-sm whitespace-pre-wrap break-words">
+            {message.content.text}
+          </p>
+        );
+    }
   };
 
   if (!client) {
@@ -172,11 +423,9 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
                             : 'bg-card border border-border'
                         }`}
                       >
-                        <p className="text-sm whitespace-pre-wrap break-words">
-                          {message.message}
-                        </p>
+                        {renderMessageContent(message)}
                       </div>
-                      
+
                       {message.viewed_at && isFromAdmin && (
                         <div className="text-xs text-muted-foreground mt-1 text-right">
                           Lida
@@ -193,27 +442,68 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
 
         {/* Área de Input */}
         <div className="p-4 border-t border-primary/20 bg-background">
-          <div className="flex gap-2">
+          <div className="flex gap-3 items-end">
+            <div className="flex flex-col gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                className="hidden"
+                onChange={handleFileChange}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={sending || attachmentUploading !== null}
+              >
+                {attachmentUploading === 'file' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Paperclip className="h-4 w-4" />
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant={isRecording ? 'destructive' : 'outline'}
+                size="icon"
+                onClick={isRecording ? stopRecording : startRecording}
+                disabled={sending || attachmentUploading === 'file'}
+              >
+                {attachmentUploading === 'audio' ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Mic className={`h-4 w-4 ${isRecording ? 'animate-pulse' : ''}`} />
+                )}
+              </Button>
+            </div>
             <Textarea
               placeholder={`Enviar mensagem para ${client.nome}...`}
               value={newMessage}
               onChange={(e) => setNewMessage(e.target.value)}
               onKeyDown={handleKeyDown}
               className="min-h-[60px] resize-none"
-              disabled={sending}
+              disabled={sending || attachmentUploading !== null}
             />
             <Button
               onClick={handleSendMessage}
-              disabled={!newMessage.trim() || sending}
+              disabled={!newMessage.trim() || sending || attachmentUploading !== null}
               size="lg"
               className="px-4"
             >
               <Send className="h-4 w-4" />
             </Button>
           </div>
-          <div className="flex justify-between items-center mt-2 text-xs text-muted-foreground">
+          <div className="flex flex-wrap justify-between items-center mt-2 text-xs text-muted-foreground gap-2">
             <span>Digite Enter para enviar, Shift+Enter para nova linha</span>
-            <span>{newMessage.length}/1000</span>
+            <div className="flex items-center gap-3">
+              {isRecording && (
+                <span className="text-destructive font-medium">
+                  Gravando áudio... {formatDuration(recordingDuration)}
+                </span>
+              )}
+              <span>{newMessage.length}/1000</span>
+            </div>
           </div>
         </div>
       </CardContent>

--- a/src/hooks/useSupportChat.ts
+++ b/src/hooks/useSupportChat.ts
@@ -2,6 +2,67 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/state/auth';
+import { Database } from '@/integrations/supabase/types';
+
+const SUPPORT_MESSAGE_PREFIX = '__support_payload__:';
+
+export type SupportMessageContent =
+  | {
+      type: 'text';
+      text: string;
+    }
+  | {
+      type: 'file';
+      url: string;
+      name: string;
+      size: number;
+      mimeType: string;
+    }
+  | {
+      type: 'audio';
+      url: string;
+      mimeType: string;
+      duration?: number;
+    };
+
+const serializeSupportMessageContent = (content: SupportMessageContent) => {
+  if (content.type === 'text') {
+    return content.text;
+  }
+
+  return `${SUPPORT_MESSAGE_PREFIX}${JSON.stringify(content)}`;
+};
+
+const parseSupportMessageContent = (message: string): SupportMessageContent => {
+  if (message.startsWith(SUPPORT_MESSAGE_PREFIX)) {
+    try {
+      const parsed = JSON.parse(message.replace(SUPPORT_MESSAGE_PREFIX, ''));
+      if (parsed?.type === 'file' || parsed?.type === 'audio') {
+        return parsed as SupportMessageContent;
+      }
+    } catch (error) {
+      console.error('Erro ao interpretar conteúdo da mensagem de suporte:', error);
+    }
+  }
+
+  return {
+    type: 'text',
+    text: message
+  };
+};
+
+const getMessagePreview = (content: SupportMessageContent) => {
+  switch (content.type) {
+    case 'file':
+      return `📎 ${content.name}`;
+    case 'audio':
+      return '🎤 Mensagem de áudio';
+    default:
+      return content.text;
+  }
+};
+
+type MessageRow = Database['public']['Tables']['messages']['Row'];
 
 export interface SupportClient {
   id: string;
@@ -21,6 +82,7 @@ export interface SupportMessage {
   from_user_id: string;
   to_user_id: string;
   message: string;
+  content: SupportMessageContent;
   created_at: string;
   viewed_at?: string;
   from_user_name?: string;
@@ -56,9 +118,9 @@ export function useSupportChat() {
       const clientsWithMessages = await Promise.all(
         (clientsData || []).map(async (client) => {
           // Buscar última mensagem
-          const { data: lastMessage } = await supabase
-            .from('messages')
-            .select('message, created_at')
+      const { data: lastMessage } = await supabase
+        .from('messages')
+        .select('message, created_at')
             .or(`and(from_user_id.eq.${client.id},to_user_id.eq.${user.id}),and(from_user_id.eq.${user.id},to_user_id.eq.${client.id})`)
             .eq('message_type', 'internal')
             .order('created_at', { ascending: false })
@@ -74,9 +136,13 @@ export function useSupportChat() {
             .eq('message_type', 'internal')
             .is('viewed_at', null);
 
+          const parsedLastMessage = lastMessage
+            ? parseSupportMessageContent(lastMessage.message)
+            : undefined;
+
           return {
             ...client,
-            last_message: lastMessage?.message,
+            last_message: parsedLastMessage ? getMessagePreview(parsedLastMessage) : lastMessage?.message,
             last_message_at: lastMessage?.created_at,
             unread_count: unreadCount || 0
           };
@@ -122,6 +188,7 @@ export function useSupportChat() {
 
           return {
             ...msg,
+            content: parseSupportMessageContent(msg.message),
             message_type: 'internal' as const,
             from_user_name: fromUser.data?.full_name || fromUser.data?.username,
             to_user_name: toUser.data?.full_name || toUser.data?.username,
@@ -162,14 +229,20 @@ export function useSupportChat() {
   };
 
   // Enviar mensagem
-  const sendMessage = async (fromUserId: string, toUserId: string, content: string) => {
+  const sendMessage = async (
+    fromUserId: string,
+    toUserId: string,
+    content: SupportMessageContent
+  ) => {
     try {
+      const serializedContent = serializeSupportMessageContent(content);
+
       const { data, error } = await supabase
         .from('messages')
         .insert({
           from_user_id: fromUserId,
           to_user_id: toUserId,
-          message: content,
+          message: serializedContent,
           message_type: 'internal'
         })
         .select('*')
@@ -183,8 +256,11 @@ export function useSupportChat() {
         supabase.from('profiles').select('username, full_name').eq('user_id', toUserId).single()
       ]);
 
+      const parsedContent = parseSupportMessageContent(data.message);
+
       const newMessage = {
         ...data,
+        content: parsedContent,
         message_type: 'internal' as const,
         from_user_name: fromUser.data?.full_name || fromUser.data?.username,
         to_user_name: toUser.data?.full_name || toUser.data?.username,
@@ -193,12 +269,12 @@ export function useSupportChat() {
       setMessages(prev => [...prev, newMessage]);
 
       // Atualizar última mensagem na lista de clientes
-      setClients(prev => 
-        prev.map(client => 
-          client.id === toUserId 
-            ? { 
-                ...client, 
-                last_message: content,
+      setClients(prev =>
+        prev.map(client =>
+          client.id === toUserId
+            ? {
+                ...client,
+                last_message: getMessagePreview(parsedContent),
                 last_message_at: new Date().toISOString()
               }
             : client
@@ -236,21 +312,29 @@ export function useSupportChat() {
           filter: `message_type=eq.internal`
         },
         (payload) => {
-          const newMessage = payload.new as SupportMessage;
-          
+          const newMessageRow = payload.new as MessageRow;
+          const parsedContent = parseSupportMessageContent(newMessageRow.message);
+
           // Se a mensagem é para este admin, adicionar à lista
-          if (newMessage.to_user_id === user.id) {
-            setMessages(prev => [...prev, newMessage]);
-            
+          if (newMessageRow.to_user_id === user.id) {
+            setMessages(prev => [
+              ...prev,
+              {
+                ...newMessageRow,
+                content: parsedContent,
+                message_type: 'internal'
+              }
+            ]);
+
             // Atualizar contagem não lida do cliente
-            setClients(prev => 
-              prev.map(client => 
-                client.id === newMessage.from_user_id 
-                  ? { 
-                      ...client, 
+            setClients(prev =>
+              prev.map(client =>
+                client.id === newMessageRow.from_user_id
+                  ? {
+                      ...client,
                       unread_count: (client.unread_count || 0) + 1,
-                      last_message: newMessage.message,
-                      last_message_at: newMessage.created_at
+                      last_message: getMessagePreview(parsedContent),
+                      last_message_at: newMessageRow.created_at
                     }
                   : client
               )


### PR DESCRIPTION
## Summary
- add file upload and audio recording controls to the support chat interface, including UI feedback
- extend support chat state handling to serialize attachment metadata and show meaningful previews for recent messages

## Testing
- npm run build *(fails: vite not found because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8806410988320971da9f6cc90954d